### PR TITLE
Change colors

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var utils = {
     },
 
     getColors: function(n) {
-        var colors = ['#A38EF3', '#7AB2EA', '#57C6B9', '#E96684', '#F0E86B', '#626c7c', '#F9A75F', '#F1B6BD', '#8C564B', '#006400'];
+        var colors = ['#A38EF3', '#7ABFEA', '#5BC69F', '#E96B88', '#F0E86B', '#C2B08C', '#F9B070', '#F19A9A', '#97DA90', '#DBB1F2'];
 
         var retColors = [];
         for(var i = 0; i<n; i++) {


### PR DESCRIPTION
This PR changes the 10 default colors used by lightning, with a slightly modified set that are overall more balanced and avoid extreme values in other brightness or saturation (the dark green and black were most problematic in this regard)

Graphic shows old and new, in each case ordered as they are sampled during random labeling (above) and in order of hue (below)

![image](https://cloud.githubusercontent.com/assets/3387500/8154950/237c9276-12f4-11e5-9e1e-8de697f8531c.png)
